### PR TITLE
rename HardFault handler to match new cortex-m-rt release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 cortex-m = "0.5"
-cortex-m-rt = { version = "0.6", features = ["device"] }
+cortex-m-rt = { version = "0.6.6", features = ["device"] }
 panic-semihosting = "0.5"
 bare-metal = { version = "0.2.4", features = ["const-fn"] }
 

--- a/openocd.gdb
+++ b/openocd.gdb
@@ -4,7 +4,7 @@ monitor arm semihosting enable
 
 # detect unhandled exceptions, hard faults and panics
 break DefaultHandler
-break UserHardFault
+break HardFault
 break rust_begin_unwind
 
 load


### PR DESCRIPTION
See changelog for cortex-m-rt v0.6.6 for more detailed explanation.